### PR TITLE
Add ESP32-S2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # CarInfo
-Used for reading data from a mystery cable found in my car that turned out to be an EGT sensor :D
-It creates a web server for displaying EGT and EGT sensor voltage. I might add more stuff in the future.
+### **ESP32-S2** EGT sensor reader.
+Currently, supports a simple website and an OLED display on Wemos S2 Pico for displaying EGT and EGT sensor voltage.
 
+### ESP32 Support:
+It is possible to use it with the regular ESP32 but an addition hardware is needed to increase the voltage of the sensor which is usually bellow 100 mV.
+To enable it ESP32_DEPRECATED has to be defined.
+> #define ESP32_DEPRECATED
+
+**Any further changes can break ESP32 support!** 
 ## Usefull stuff:
-### [Wiring diagram](https://esp32.com/download/file.php?id=1205&sid=b2a025eb132bba33aadf4628eb28b5c8) for increasing the voltage by 100 mV due to ESP32 ADC limitation
 ### Typical [voltage output](https://www.omega.com/en-us/resources/k-type-thermocouples) for the K type Thermocouple
+ 

--- a/include/settings.h
+++ b/include/settings.h
@@ -7,19 +7,152 @@
 
 #include <Arduino.h>
 
-static constexpr int EGT_SENSOR_PIN       = 36;      // ADC1 CH0
-static constexpr int VOLTAGE_INCREASE     = 100;     // mV
-static constexpr int V_MAX                = 950;     // mV
-static constexpr int ADC_WIDTH            = 12;      // bits
-static constexpr int ADC_RESOLUTION       = 4095;    // 12 bits
-static constexpr adc_attenuation_t ADC_DB = ADC_0db; // 100 mV -> 950 mV
+#include "bootlegUniquePtr.h"
+
+#define HTTP_SERVER // Enables http server
+#define DEBUG       // Enables debug serial print
+#define USE_LCD
+
+#ifdef DEBUG
+#define SERIAL_INIT(baud) Serial.begin(baud)
+#define LOG(...) Serial.println(__VA_ARGS__)
+#else
+#define SERIAL_INIT(baud) NOP()
+#define LOG(...) NOP()
+#endif
 
 static constexpr float TEMP_VOLTAGE_MULTIPLIER = 4.096f; // 4.096 mV in 100 °C
+
+#ifdef HTTP_SERVER
+static const char* SSID = "SSID";
+static const char* PASSWORD = "PASSWORD";
+#endif
+
+#ifndef ESP32_DEPRECATED
+#include <driver/adc.h>
+#include <esp_adc_cal.h>
+
+static constexpr adc1_channel_t EGT_SENSOR_PIN = ADC1_CHANNEL_0;   // ADC1 PIN1
+static constexpr adc_bits_width_t ADC_WIDTH    = ADC_WIDTH_BIT_13; // bits
+static constexpr adc_atten_t ADC_DB            = ADC_ATTEN_DB_0;   // 0 mV -> 750 mV
+static constexpr uint32_t ADC_MAX_VOLTAGE      = 750;              // mV
+static constexpr uint32_t ADC_MAX_READING      = 4095;             // 13 bits, continuous read mode
+
+static esp_adc_cal_characteristics_t* gADCCharacteristic = nullptr;
+
+static void initializeADC()
+{
+    /*if (esp_adc_cal_check_efuse(ESP_ADC_CAL_VAL_EFUSE_TP) == 0)
+        esp_adc_cal_characterize(ADC_UNIT_1, ADC_DB, ADC_WIDTH, 0, gADCCharacteristic);*/
+
+    adc1_config_width(ADC_WIDTH);
+    adc1_config_channel_atten(EGT_SENSOR_PIN, ADC_DB);
+}
+
+static float getADCVoltage()
+{
+    if (gADCCharacteristic)
+        return (float)esp_adc_cal_raw_to_voltage(adc1_get_raw(EGT_SENSOR_PIN), gADCCharacteristic);
+
+    return (float)adc1_get_raw(EGT_SENSOR_PIN) * ADC_MAX_VOLTAGE / ADC_MAX_READING;
+}
+
+#ifdef USE_LCD
+#include <SSD1306Wire.h>
+
+static constexpr bool DISPLAY_FLIPPED = true;
+
+std::unique_ptr<SSD1306Wire> gDisplay = nullptr;
+
+static void displayText(const String& data, int16_t x = 0, int16_t y = 0)
+{
+    if (!gDisplay)
+    {
+        LOG("Display is not initialized!");
+        return;
+    }
+
+    gDisplay->drawString(x, y, data);
+    gDisplay->display();
+}
+
+static void initializeDisplay()
+{
+    gDisplay = make_unique<SSD1306Wire>(0x3C, SDA, SCL, GEOMETRY_128_32);
+
+    gDisplay->init();
+    delay(250);
+    gDisplay->clear();
+    delay(100);
+
+    if (DISPLAY_FLIPPED)
+        gDisplay->flipScreenVertically();
+
+    gDisplay->setFont(ArialMT_Plain_10);
+    gDisplay->setColor(WHITE);
+    delay(100);
+    displayText("Initializing...", 0, 10);
+}
+
+static void clearDisplay()
+{
+    if (!gDisplay)
+        return;
+
+    gDisplay->clear();
+    delay(200);
+}
+#endif //USE_LCD
+#else
+static constexpr int EGT_SENSOR_PIN       = 36;      // ADC1 CH0
+static constexpr int VOLTAGE_INCREASE     = 100;     // mV
+static constexpr int ADC_WIDTH            = 12;      // bits
+static constexpr adc_attenuation_t ADC_DB = ADC_0db; // 100 mV -> 950 mV
+static constexpr int ADC_MAX_VOLTAGE      = 950;     // mV
+static constexpr int ADC_MAX_READING      = 4095;    // 12 bits
+
+static void initializeADC()
+{
+    analogSetWidth(ADC_WIDTH);
+    analogSetAttenuation(ADC_DB);
+}
+
+static float getADCVoltage()
+{
+    return analogReadMilliVolts(EGT_SENSOR_PIN) - VOLTAGE_INCREASE;
+}
+
+#ifdef  USE_LCD
+#include <../lib/TinyLiquidCrystal_I2C/TinyLCI2C.h>
 
 static constexpr int LCD_ADDRESS = 0x27; // 0x20?
 static constexpr int LCD_LINES   = 2;
 
-static const char* SSID = "SSID";
-static const char* PASSWORD = "PASSWORD";
+static std::unique_ptr<TinyLCI2C> gDisplay = nullptr;
 
+static void displayText(const char* data, int x = 0, int y = 0)
+{
+    if (gDisplay)
+        gDisplay->print(data);
+    else
+        LOG("Display is not initialized!");
+}
+
+static void initializeDisplay()
+{
+    gDisplay = make_unique<TinyLCI2C>(LCD_ADDRESS, LCD_LINES);
+    gDisplay->print("Initializing");
+}
+
+static void clearDisplay()
+{
+    return;
+}
+#endif //USE_LCD
+#endif //ESP32_S2
+#ifndef USE_LCD
+static void displayText(const char* data, int x = 0, int y = 0) {}
+static void initializeDisplay() {}
+static void clearDisplay() {}
+#endif //USE_LCD
 #endif //CARINFO_SETTINGS_H

--- a/lib/TinyLiquidCrystal_I2C/TinyLCI2C.h
+++ b/lib/TinyLiquidCrystal_I2C/TinyLCI2C.h
@@ -6,8 +6,6 @@
 
 #include <cstdio>
 
-#define LCD_BACKLIGHT
-
 class TinyLCI2C
 {
 public:
@@ -27,10 +25,10 @@ private:
     static constexpr uint8_t LCD_DISPLAYCONTROL = 0x08;
     static constexpr uint8_t LCD_ENTRYLEFT      = 0x02;
     static constexpr uint8_t LCD_ENTRYMODESET   = 0x04;
-#ifdef LCD_BACKLIGHT
-    static constexpr uint8_t LCD_BACKLIGHTVAL   = 0x08;
-#else
+#ifdef LCD_NOBACKLIGHT
     static constexpr uint8_t LCD_BACKLIGHTVAL   = 0x00;
+#else
+    static constexpr uint8_t LCD_BACKLIGHTVAL   = 0x08;
 #endif
 
     uint8_t mLcdAddress;

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,5 +10,11 @@
 
 [env:esp32dev]
 platform = espressif32
-board = esp32dev
+board = lolin_s2_pico
 framework = arduino
+lib_deps = 
+	thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@4.4.0
+	adafruit/Adafruit BusIO@^1.14.1
+	adafruit/Adafruit GFX Library@^1.11.5
+	SPI
+	pasko-zh/Brzo I2C@^1.3.3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,66 +1,72 @@
-#include <Arduino.h>
-#include <../lib/TinyLiquidCrystal_I2C/TinyLCI2C.h>
-
-#include "webServerHandler.h"
-#include "settings.h"
-
-// Wiring diagram for increasing the EGT sensor voltage output by 100 mV:
-// https://esp32.com/download/file.php?id=1205&sid=b2a025eb132bba33aadf4628eb28b5c8
-
 // Voltages of the EGT sensors, should be checked with the actual sensor datasheet:
 // https://www.omega.com/en-us/resources/k-type-thermocouples
 
-std::unique_ptr<WebServerHandler> serverHandler = nullptr;
-std::unique_ptr<TinyLCI2C> lcd = nullptr;
+#include <string>
 
-static float getEgtVoltage()
+#include "settings.h"
+
+#ifdef HTTP_SERVER
+#include "webServerHandler.h"
+std::unique_ptr<WebServerHandler> serverHandler = nullptr;
+static void initializeServer()
 {
-    return analogRead(EGT_SENSOR_PIN) * V_MAX * ADC_RESOLUTION;
+    serverHandler = WebServerHandler::gen(SSID, PASSWORD);
 }
+
+static void pushDataToServer(const std::string& data)
+{
+    if (serverHandler->isConnected())
+        serverHandler->pushData(data);
+    else
+        LOG("Could not upload the data");
+}
+#else
+static void initializeServer() {}
+
+static void pushDataToServer(const std::string& data)
+{
+    LOG("Server is disabled");
+}
+#endif
 
 static float getEgtTemp(float egtVoltage)
 {
-    return (egtVoltage * TEMP_VOLTAGE_MULTIPLIER * 100) - VOLTAGE_INCREASE;
+    return (float)egtVoltage * (100 / TEMP_VOLTAGE_MULTIPLIER);
 }
 
 void setup()
 {
-    Serial.begin(115200);
-    analogSetWidth(ADC_WIDTH);
-    analogSetAttenuation(ADC_DB);
+    SERIAL_INIT(115200);
 
-    serverHandler = WebServerHandler::gen(SSID, PASSWORD);
+    initializeDisplay();
+    initializeServer();
+    delay(250);
+    initializeADC();
 
-    lcd = make_unique<TinyLCI2C>(LCD_ADDRESS, LCD_LINES);
-    lcd->print("Initializing");
 
     delay(1000);
 }
 
 void loop()
 {
-    float egtVoltage      = getEgtVoltage();
-    uint32_t egtVoltage2  = analogReadMilliVolts(EGT_SENSOR_PIN) - VOLTAGE_INCREASE;
-    float egtTemp         = getEgtTemp(egtVoltage);
 
-    std::string data = "EGT Voltage: " + std::to_string(egtVoltage) + " V\n" +
-                       "EGT Voltage2: " + std::to_string(egtVoltage2) + " mV\n" +
-                       "EGT Temp: " + std::to_string(egtTemp) + " °C";
+    clearDisplay();
 
-    Serial.println(data.c_str());
+    float egtVoltage = getADCVoltage();
+    const float egtTemp = getEgtTemp(egtVoltage);
 
-    if (serverHandler->isConnected())
-        serverHandler->pushData(data);
+    std::string data = "EGT Voltage: " + std::to_string(egtVoltage) + " mV<br>" +
+                       "EGT Temp: " + std::to_string(egtTemp) + " &deg;C";
+
+    LOG(data.c_str());
+    pushDataToServer(data);
 
     // TODO: Temporary solution, this should be change when the button is pressed
     data = "V1: " + std::to_string(egtVoltage);
-    lcd->print(data.c_str());
-    delay(500);
-
-    data = "V2: " + std::to_string(egtVoltage2);
-    lcd->print(data.c_str());
-    delay(500);
-
+    displayText(data.c_str(), 0, 0);
     data = "Temp " + std::to_string(egtTemp) + " C";
-    lcd->print(data.c_str());
+    displayText(data.c_str(), 0, 20);
+
+    egtVoltage++;
+    delay(1000);
 }

--- a/src/webServerHandler.cpp
+++ b/src/webServerHandler.cpp
@@ -15,7 +15,7 @@ std::unique_ptr<WebServerHandler> WebServerHandler::gen(const char* ssid, const 
 WebServerHandler::WebServerHandler(const char* ssid, const char* password)
 {
     WiFi.begin(ssid, password);
-    for (int timeout = 0; WiFi.status() != WL_CONNECTED; timeout++)
+    for (int timeout = 0; WiFiClass::status() != WL_CONNECTED; timeout++)
     {
         if (timeout == 50)
             return;
@@ -50,7 +50,9 @@ bool WebServerHandler::isConnected()
 
 void WebServerHandler::pushData(const std::string& data)
 {
-    webpage = "<!DOCTYPE html><html>\n"
+    server->handleClient();
+
+    webpage = "<!DOCTYPE html><html><meta http-equiv=\"refresh\" content=\"1\">"
               "<body>";
     webpage += data + "</body></html>";
 }


### PR DESCRIPTION
ESP32-S2 is now used. Original ESP32 code has been disabled, can be used with #define ESP32_DEPRECATED.

Added an option to disable a web server which saves 22 KB of RAM and 494 KB of Flash.